### PR TITLE
🤖 issue-4: 商品ページURLの修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,9 @@ Route definitions in `app/routes.ts`:
 
 ```typescript
 export default [
-  index("routes/home.tsx"), // /
-  route("/login", "routes/login.tsx"), // /login
-  route("/stock", "routes/stock.tsx"), // /stock
+  index('routes/home.tsx'), // /
+  route('/login', 'routes/login.tsx'), // /login
+  route('/stock', 'routes/stock.tsx'), // /stock
 ] satisfies RouteConfig;
 ```
 

--- a/app/components/StockTable/StockTable.tsx
+++ b/app/components/StockTable/StockTable.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react';
 import * as styles from './StockTable.css';
+import { purchaseUrl } from '~/utils/const';
 
 interface StockItem {
   id: number;
@@ -32,7 +33,7 @@ export const StockTable: FC<StockTableProps> = ({ items }) => {
               <td className={styles.td}>{item.count}</td>
               <td className={styles.td}>
                 <a
-                  href={decodeURIComponent(item.url)}
+                  href={`${purchaseUrl}${decodeURIComponent(item.url)}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className={styles.link}


### PR DESCRIPTION
## 概要

商品ページURLが正しく動作するように修正しました。

## 関連 Issue

#4

## 対応詳細

- StockTableコンポーネントでpurchaseUrlを使用してAmazonのベースURLを付与
- デコードされた商品URLの前にhttps://www.amazon.co.jp/を追加
- 商品リンクが正常に機能するようになりました

🤖 Generated with [Claude Code](https://claude.ai/code)