### PR TITLE
🤖 issue-9: 家計簿登録API接続機能を実装

### DIFF
--- a/app/components/pages/householdAccountBook.tsx
+++ b/app/components/pages/householdAccountBook.tsx
@@ -19,17 +19,19 @@ export const HouseholdAccountBookPage: FC = () => {
     resolver: zodResolver(spentSchema),
     mode: 'onChange',
     defaultValues: {
-      credit: 0,
-      electricity: 0,
-      gas: 0,
-      water: 0,
-      other: 0,
+      credit: '0',
+      electricity: '0',
+      gas: '0',
+      water: '0',
+      other: '0',
     },
   });
 
   const onSubmit = (data: SpentFormData) => {
     // 念のため送信前に負の値をチェック
-    const hasNegativeValue = Object.values(data).some((value) => value < 0);
+    const hasNegativeValue = Object.values(data).some(
+      (value) => Number(value) < 0
+    );
     if (hasNegativeValue) {
       alert('負の値は入力できません');
       return;
@@ -39,39 +41,25 @@ export const HouseholdAccountBookPage: FC = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Input
-        label="ガス代"
-        type="number"
-        min="0"
-        {...register('gas', { valueAsNumber: true })}
-        error={errors.gas?.message}
-      />
+      <Input label="ガス代" {...register('gas')} error={errors.gas?.message} />
       <Input
         label="電気代"
-        type="number"
-        min="0"
-        {...register('electricity', { valueAsNumber: true })}
+        {...register('electricity')}
         error={errors.electricity?.message}
       />
       <Input
         label="水道代"
-        type="number"
-        min="0"
-        {...register('water', { valueAsNumber: true })}
+        {...register('water')}
         error={errors.water?.message}
       />
       <Input
         label="カード代"
-        type="number"
-        min="0"
-        {...register('credit', { valueAsNumber: true })}
+        {...register('credit')}
         error={errors.credit?.message}
       />
       <Input
         label="その他"
-        type="number"
-        min="0"
-        {...register('other', { valueAsNumber: true })}
+        {...register('other')}
         error={errors.other?.message}
       />
       <Button type="submit" disabled={!isValid}>

--- a/app/components/pages/householdAccountBook.tsx
+++ b/app/components/pages/householdAccountBook.tsx
@@ -26,25 +26,39 @@ export const HouseholdAccountBookPage: FC = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Input label="ガス代" {...register('gas')} error={errors.gas?.message} />
+      <Input
+        label="ガス代"
+        type="number"
+        min="0"
+        {...register('gas', { valueAsNumber: true })}
+        error={errors.gas?.message}
+      />
       <Input
         label="電気代"
-        {...register('electricity')}
+        type="number"
+        min="0"
+        {...register('electricity', { valueAsNumber: true })}
         error={errors.electricity?.message}
       />
       <Input
         label="水道代"
-        {...register('water')}
+        type="number"
+        min="0"
+        {...register('water', { valueAsNumber: true })}
         error={errors.water?.message}
       />
       <Input
         label="カード代"
-        {...register('credit')}
+        type="number"
+        min="0"
+        {...register('credit', { valueAsNumber: true })}
         error={errors.credit?.message}
       />
       <Input
         label="その他"
-        {...register('other')}
+        type="number"
+        min="0"
+        {...register('other', { valueAsNumber: true })}
         error={errors.other?.message}
       />
       <Button type="submit" disabled={!isValid}>

--- a/app/components/pages/householdAccountBook.tsx
+++ b/app/components/pages/householdAccountBook.tsx
@@ -18,9 +18,22 @@ export const HouseholdAccountBookPage: FC = () => {
   } = useForm<SpentFormData>({
     resolver: zodResolver(spentSchema),
     mode: 'onChange',
+    defaultValues: {
+      credit: 0,
+      electricity: 0,
+      gas: 0,
+      water: 0,
+      other: 0,
+    },
   });
 
   const onSubmit = (data: SpentFormData) => {
+    // 念のため送信前に負の値をチェック
+    const hasNegativeValue = Object.values(data).some((value) => value < 0);
+    if (hasNegativeValue) {
+      alert('負の値は入力できません');
+      return;
+    }
     submitSpentData(data);
   };
 

--- a/app/components/pages/householdAccountBook.tsx
+++ b/app/components/pages/householdAccountBook.tsx
@@ -18,13 +18,6 @@ export const HouseholdAccountBookPage: FC = () => {
   } = useForm<SpentFormData>({
     resolver: zodResolver(spentSchema),
     mode: 'onChange',
-    defaultValues: {
-      credit: '0',
-      electricity: '0',
-      gas: '0',
-      water: '0',
-      other: '0',
-    },
   });
 
   const onSubmit = (data: SpentFormData) => {

--- a/app/config.ts
+++ b/app/config.ts
@@ -1,1 +1,1 @@
-export const API_URL = process.env.API_URL || '';
+export const API_URL = import.meta.env.VITE_API_URL || '';

--- a/app/hooks/useSpent.ts
+++ b/app/hooks/useSpent.ts
@@ -16,11 +16,11 @@ export const useSpent = () => {
   const submitSpentData = async (data: SpentFormData) => {
     try {
       const requestData: PostSpentData = {
-        credit: data.credit,
-        electricity: data.electricity,
-        gas: data.gas,
-        water: data.water,
-        other: data.other,
+        credit: Number(data.credit),
+        electricity: Number(data.electricity),
+        gas: Number(data.gas),
+        water: Number(data.water),
+        other: Number(data.other),
       };
 
       await axios.post(`${API_URL}/spent/month`, requestData);

--- a/app/hooks/useSpent.ts
+++ b/app/hooks/useSpent.ts
@@ -1,16 +1,40 @@
+import axios from 'axios';
+import { useNavigate } from 'react-router';
 import type { SpentFormData } from '~/schemas/spentValidation';
+import type { PostSpentData, ErrorResponse } from '~/types/api';
+import { API_URL } from '~/config';
 
 /**
  * 家計簿 支払額関連hook.
  */
 export const useSpent = () => {
+  const navigate = useNavigate();
+
   /**
    * DBに入力値を登録.
-   * TODO:処理作成
    */
-  const submitSpentData = (data: SpentFormData) => {
-    console.log('入力データ:', data);
-    alert('登録しました');
+  const submitSpentData = async (data: SpentFormData) => {
+    try {
+      const requestData: PostSpentData = {
+        credit: Number(data.credit),
+        electricity: Number(data.electricity),
+        gas: Number(data.gas),
+        water: Number(data.water),
+        other: Number(data.other),
+      };
+
+      await axios.post(`${API_URL}/spent/month`, requestData);
+
+      alert('登録しました');
+      navigate('/home');
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        const errorData = error.response.data as ErrorResponse;
+        alert(errorData.message || 'エラーが発生しました');
+      } else {
+        alert('予期しないエラーが発生しました');
+      }
+    }
   };
 
   return { submitSpentData };

--- a/app/hooks/useSpent.ts
+++ b/app/hooks/useSpent.ts
@@ -16,11 +16,11 @@ export const useSpent = () => {
   const submitSpentData = async (data: SpentFormData) => {
     try {
       const requestData: PostSpentData = {
-        credit: Number(data.credit),
-        electricity: Number(data.electricity),
-        gas: Number(data.gas),
-        water: Number(data.water),
-        other: Number(data.other),
+        credit: data.credit,
+        electricity: data.electricity,
+        gas: data.gas,
+        water: data.water,
+        other: data.other,
       };
 
       await axios.post(`${API_URL}/spent/month`, requestData);

--- a/app/schemas/spentValidation.test.ts
+++ b/app/schemas/spentValidation.test.ts
@@ -1,0 +1,204 @@
+import { describe, test, expect } from 'vitest';
+import { spentSchema } from './spentValidation';
+
+describe('spentValidation', () => {
+  describe('正常なケース', () => {
+    test('すべて0の場合', () => {
+      const input = {
+        credit: 0,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    test('正の数値の場合', () => {
+      const input = {
+        credit: 1000,
+        electricity: 5000,
+        gas: 3000,
+        water: 2000,
+        other: 500,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+
+    test('最大値の場合', () => {
+      const input = {
+        credit: 9999999999,
+        electricity: 9999999999,
+        gas: 9999999999,
+        water: 9999999999,
+        other: 9999999999,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('異常なケース', () => {
+    test('負の値の場合', () => {
+      const input = {
+        credit: -1,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('too_small');
+      }
+    });
+
+    test('複数の負の値の場合', () => {
+      const input = {
+        credit: -100,
+        electricity: -200,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toHaveLength(2);
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[1].path).toEqual(['electricity']);
+      }
+    });
+
+    test('最大値を超える場合', () => {
+      const input = {
+        credit: 10000000000, // 9999999999 + 1
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('too_big');
+      }
+    });
+
+    test('文字列の場合', () => {
+      const input = {
+        credit: 'invalid',
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('invalid_type');
+      }
+    });
+
+    test('undefinedの場合', () => {
+      const input = {
+        credit: undefined,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('invalid_type');
+      }
+    });
+
+    test('nullの場合', () => {
+      const input = {
+        credit: null,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('invalid_type');
+      }
+    });
+
+    test('NaNの場合', () => {
+      const input = {
+        credit: NaN,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('invalid_type');
+      }
+    });
+
+    test('Infinityの場合', () => {
+      const input = {
+        credit: Infinity,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('invalid_type');
+      }
+    });
+  });
+
+  describe('React Hook Formとの連携を想定したテスト', () => {
+    test('valueAsNumberで-1が設定された場合', () => {
+      // React Hook Formのvalues.asNumberで負の値が入る可能性があるケース
+      const input = {
+        credit: -1,
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toContain('0以上');
+      }
+    });
+
+    test('空文字列から0に変換されるケース', () => {
+      // 入力フィールドが空の場合、valueAsNumberでNaNになる可能性
+      const input = {
+        credit: NaN, // 空文字列のvalueAsNumberはNaN
+        electricity: 0,
+        gas: 0,
+        water: 0,
+        other: 0,
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/app/schemas/spentValidation.test.ts
+++ b/app/schemas/spentValidation.test.ts
@@ -3,37 +3,37 @@ import { spentSchema } from './spentValidation';
 
 describe('spentValidation', () => {
   describe('正常なケース', () => {
-    test('すべて0の場合', () => {
+    test('すべて"0"の場合', () => {
       const input = {
-        credit: 0,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        credit: '0',
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(true);
     });
 
-    test('正の数値の場合', () => {
+    test('正の数値文字列の場合', () => {
       const input = {
-        credit: 1000,
-        electricity: 5000,
-        gas: 3000,
-        water: 2000,
-        other: 500,
+        credit: '1000',
+        electricity: '5000',
+        gas: '3000',
+        water: '2000',
+        other: '500',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(true);
     });
 
-    test('最大値の場合', () => {
+    test('最大桁数の場合', () => {
       const input = {
-        credit: 9999999999,
-        electricity: 9999999999,
-        gas: 9999999999,
-        water: 9999999999,
-        other: 9999999999,
+        credit: '9999999999',
+        electricity: '9999999999',
+        gas: '9999999999',
+        water: '9999999999',
+        other: '9999999999',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(true);
@@ -41,29 +41,29 @@ describe('spentValidation', () => {
   });
 
   describe('異常なケース', () => {
-    test('負の値の場合', () => {
+    test('負の値文字列の場合', () => {
       const input = {
-        credit: -1,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        credit: '-1',
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0].path).toEqual(['credit']);
-        expect(result.error.issues[0].code).toBe('too_small');
+        expect(result.error.issues[0].code).toBe('custom');
       }
     });
 
-    test('複数の負の値の場合', () => {
+    test('複数の負の値文字列の場合', () => {
       const input = {
-        credit: -100,
-        electricity: -200,
-        gas: 0,
-        water: 0,
-        other: 0,
+        credit: '-100',
+        electricity: '-200',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
@@ -74,13 +74,13 @@ describe('spentValidation', () => {
       }
     });
 
-    test('最大値を超える場合', () => {
+    test('最大桁数を超える場合', () => {
       const input = {
-        credit: 10000000000, // 9999999999 + 1
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        credit: '12345678901', // 11桁
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
@@ -90,29 +90,45 @@ describe('spentValidation', () => {
       }
     });
 
-    test('文字列の場合', () => {
+    test('無効な文字列の場合', () => {
       const input = {
         credit: 'invalid',
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.issues[0].path).toEqual(['credit']);
-        expect(result.error.issues[0].code).toBe('invalid_type');
+        expect(result.error.issues[0].code).toBe('custom');
+      }
+    });
+
+    test('空文字列の場合', () => {
+      const input = {
+        credit: '',
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('too_small');
       }
     });
 
     test('undefinedの場合', () => {
       const input = {
         credit: undefined,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
@@ -125,42 +141,10 @@ describe('spentValidation', () => {
     test('nullの場合', () => {
       const input = {
         credit: null,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
-      };
-      const result = spentSchema.safeParse(input);
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].path).toEqual(['credit']);
-        expect(result.error.issues[0].code).toBe('invalid_type');
-      }
-    });
-
-    test('NaNの場合', () => {
-      const input = {
-        credit: NaN,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
-      };
-      const result = spentSchema.safeParse(input);
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.issues[0].path).toEqual(['credit']);
-        expect(result.error.issues[0].code).toBe('invalid_type');
-      }
-    });
-
-    test('Infinityの場合', () => {
-      const input = {
-        credit: Infinity,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
@@ -172,14 +156,14 @@ describe('spentValidation', () => {
   });
 
   describe('React Hook Formとの連携を想定したテスト', () => {
-    test('valueAsNumberで-1が設定された場合', () => {
-      // React Hook Formのvalues.asNumberで負の値が入る可能性があるケース
+    test('負の値文字列が入力された場合', () => {
+      // ユーザーがテキストフィールドに負の値を入力したケース
       const input = {
-        credit: -1,
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        credit: '-1',
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
@@ -188,17 +172,33 @@ describe('spentValidation', () => {
       }
     });
 
-    test('空文字列から0に変換されるケース', () => {
-      // 入力フィールドが空の場合、valueAsNumberでNaNになる可能性
+    test('空文字列の場合', () => {
+      // 入力フィールドが空の場合
       const input = {
-        credit: NaN, // 空文字列のvalueAsNumberはNaN
-        electricity: 0,
-        gas: 0,
-        water: 0,
-        other: 0,
+        credit: '', // 空文字列
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
       };
       const result = spentSchema.safeParse(input);
       expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].code).toBe('too_small');
+      }
+    });
+
+    test('小数点を含む数値文字列の場合', () => {
+      // 小数点を含む数値が入力された場合
+      const input = {
+        credit: '100.5',
+        electricity: '0',
+        gas: '0',
+        water: '0',
+        other: '0',
+      };
+      const result = spentSchema.safeParse(input);
+      expect(result.success).toBe(true); // 小数点も有効な数値として扱う
     });
   });
 });

--- a/app/schemas/spentValidation.test.ts
+++ b/app/schemas/spentValidation.test.ts
@@ -189,7 +189,7 @@ describe('spentValidation', () => {
     });
 
     test('小数点を含む数値文字列の場合', () => {
-      // 小数点を含む数値が入力された場合
+      // 小数点を含む数値が入力された場合（整数のみ許可）
       const input = {
         credit: '100.5',
         electricity: '0',
@@ -198,7 +198,11 @@ describe('spentValidation', () => {
         other: '0',
       };
       const result = spentSchema.safeParse(input);
-      expect(result.success).toBe(true); // 小数点も有効な数値として扱う
+      expect(result.success).toBe(false); // 整数のみ許可なのでエラー
+      if (!result.success) {
+        expect(result.error.issues[0].path).toEqual(['credit']);
+        expect(result.error.issues[0].code).toBe('custom');
+      }
     });
   });
 });

--- a/app/schemas/spentValidation.ts
+++ b/app/schemas/spentValidation.ts
@@ -2,9 +2,15 @@ import { z } from 'zod';
 import { errorMessages } from '~/utils/const';
 
 const amountValidation = z
-  .number()
-  .min(0, errorMessages.amountPositive)
-  .max(9999999999, errorMessages.amountMaxLength);
+  .string()
+  .min(1, errorMessages.amountRequired)
+  .max(10, errorMessages.amountMaxLength)
+  .refine((val) => !isNaN(Number(val)), {
+    message: errorMessages.amountRequired,
+  })
+  .refine((val) => Number(val) >= 0, {
+    message: errorMessages.amountPositive,
+  });
 
 export const spentSchema = z.object({
   credit: amountValidation,

--- a/app/schemas/spentValidation.ts
+++ b/app/schemas/spentValidation.ts
@@ -2,15 +2,9 @@ import { z } from 'zod';
 import { errorMessages } from '~/utils/const';
 
 const amountValidation = z
-  .string()
-  .min(1, errorMessages.amountRequired)
-  .max(10, errorMessages.amountMaxLength)
-  .refine((val) => !isNaN(Number(val)), {
-    message: errorMessages.amountRequired,
-  })
-  .refine((val) => Number(val) >= 0, {
-    message: errorMessages.amountPositive,
-  });
+  .number()
+  .min(0, errorMessages.amountPositive)
+  .max(9999999999, errorMessages.amountMaxLength);
 
 export const spentSchema = z.object({
   credit: amountValidation,

--- a/app/schemas/spentValidation.ts
+++ b/app/schemas/spentValidation.ts
@@ -3,14 +3,26 @@ import { errorMessages } from '~/utils/const';
 
 const amountValidation = z
   .string()
-  .min(1, errorMessages.amountRequired)
-  .max(10, errorMessages.amountMaxLength)
-  .refine((val) => !isNaN(Number(val)), {
-    message: errorMessages.amountRequired,
-  })
-  .refine((val) => Number(val) >= 0, {
-    message: errorMessages.amountPositive,
-  });
+  .min(1, errorMessages.amountRequired) // 空文字列はエラー
+  .max(10, errorMessages.amountMaxLength) // 10桁以内
+  .refine(
+    (val) => {
+      // 数値に変換可能かチェック
+      return !isNaN(Number(val)) && Number(val) % 1 === 0;
+    },
+    {
+      message: errorMessages.amountRequired,
+    }
+  )
+  .refine(
+    (val) => {
+      // 0以上の整数かチェック
+      return Number(val) >= 0;
+    },
+    {
+      message: errorMessages.amountPositive,
+    }
+  );
 
 export const spentSchema = z.object({
   credit: amountValidation,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^8.39.0",
         "@typescript-eslint/parser": "^8.39.0",
         "@vanilla-extract/vite-plugin": "^5.1.1",
+        "@vitest/ui": "^3.2.4",
         "eslint": "^9.33.0",
         "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -37,7 +38,8 @@
         "prettier": "^3.6.2",
         "typescript": "^5.8.3",
         "vite": "^6.3.3",
-        "vite-tsconfig-paths": "^5.1.4"
+        "vite-tsconfig-paths": "^5.1.4",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1457,6 +1459,13 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@react-router/dev": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/@react-router/dev/-/dev-7.8.0.tgz",
@@ -1924,6 +1933,23 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
+      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2350,6 +2376,164 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-3.2.4.tgz",
+      "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.14",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "3.2.4"
+      }
+    },
+    "node_modules/@vitest/ui/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2604,6 +2788,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types-flow": {
@@ -2913,6 +3107,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.2.tgz",
+      "integrity": "sha512-kx7GHSOBiiIQ+DDgMP6YMtYkb/3Usm2nUYblNEM9P+/OfkuP7OjfoDlq/DCe1OU0GsREUa0rNAxZmzxgO6+jWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2944,6 +3155,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3248,6 +3469,16 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -4107,6 +4338,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
+      "integrity": "sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -4250,6 +4491,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5800,6 +6048,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6037,6 +6292,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -6446,6 +6711,16 @@
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/periscopic": {
       "version": "4.0.2",
@@ -7291,6 +7566,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7302,6 +7584,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sirv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.1.tgz",
+      "integrity": "sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/source-map": {
@@ -7369,6 +7666,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -7377,6 +7681,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
+      "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -7622,6 +7933,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
+      "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7664,6 +7995,20 @@
         "url": "https://opencollective.com/synckit"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -7679,6 +8024,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
+      "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7701,6 +8076,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8144,6 +8529,86 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/which/-/which-3.0.1.tgz",
@@ -8247,6 +8712,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "start": "react-router-serve ./build/server/index.js",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:run": "vitest run",
     "typecheck": "react-router typegen && tsc",
     "prepare": "husky"
   },
@@ -35,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^8.39.0",
     "@typescript-eslint/parser": "^8.39.0",
     "@vanilla-extract/vite-plugin": "^5.1.1",
+    "@vitest/ui": "^3.2.4",
     "eslint": "^9.33.0",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-jsx-a11y": "^6.10.2",
@@ -45,6 +49,7 @@
     "prettier": "^3.6.2",
     "typescript": "^5.8.3",
     "vite": "^6.3.3",
-    "vite-tsconfig-paths": "^5.1.4"
+    "vite-tsconfig-paths": "^5.1.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: 'node',
+    globals: true,
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    exclude: ['node_modules', 'build'],
+  },
+});


### PR DESCRIPTION
## 概要

家計簿登録ページ(/household-account-book)において、フォーム送信時にAPI(post:${API_URL}/spent/month)を呼び出す機能を実装しました。

## 関連 Issue

Closes #9

## 対応詳細

- useSpentフックにAPI呼び出し機能を追加
- PostSpentDataインターフェースを使用してリクエストbodyを作成
- 各項目（credit, electricity, gas, water, other）を数値で送信（0の場合も0で送信）
- APIエラー時はエラーメッセージをalertで表示
- 登録成功時は「登録しました」をalertで表示後、/homeページに自動遷移
- エラーハンドリングでaxiosエラーとGenericエラーに対応

🤖 Generated with [Claude Code](https://claude.ai/code)