### PR TITLE
🤖 issue-15: LINE Messaging APIとの接続

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# LINE Messaging API設定
+LINE_CHANNEL_ACCESS_TOKEN=your_line_channel_access_token_here
+LINE_USER_ID=your_line_user_id_here

--- a/app/lib/lineClient.ts
+++ b/app/lib/lineClient.ts
@@ -1,0 +1,55 @@
+import type { LinePushMessagePayload, LineApiResponse } from '~/types/line';
+
+const LINE_API_BASE_URL = 'https://api.line.me/v2/bot';
+
+export const sendPushMessage = async (
+  channelAccessToken: string,
+  userID: string,
+  message: string,
+  notificationDisabled = false
+): Promise<LineApiResponse> => {
+  const payload: LinePushMessagePayload = {
+    to: userID,
+    messages: [
+      {
+        type: 'text',
+        text: message,
+      },
+    ],
+    notificationDisabled,
+  };
+
+  try {
+    const response = await fetch(`${LINE_API_BASE_URL}/message/push`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${channelAccessToken}`,
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `LINE API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return {
+      status: response.status,
+      message: 'Message sent successfully',
+    };
+  } catch (error) {
+    if (error instanceof Error) {
+      return {
+        status: 500,
+        message: error.message,
+      };
+    }
+    return {
+      status: 500,
+      message: 'Unknown error occurred',
+    };
+  }
+};

--- a/app/types/env.ts
+++ b/app/types/env.ts
@@ -1,0 +1,6 @@
+interface LineEnvConfig {
+  LINE_CHANNEL_ACCESS_TOKEN: string;
+  LINE_USER_ID: string;
+}
+
+export type { LineEnvConfig };

--- a/app/types/line.ts
+++ b/app/types/line.ts
@@ -1,0 +1,17 @@
+interface LineMessage {
+  type: 'text';
+  text: string;
+}
+
+interface LinePushMessagePayload {
+  to: string;
+  messages: LineMessage[];
+  notificationDisabled?: boolean;
+}
+
+interface LineApiResponse {
+  status: number;
+  message?: string;
+}
+
+export type { LineMessage, LinePushMessagePayload, LineApiResponse };

--- a/app/utils/lineMessaging.ts
+++ b/app/utils/lineMessaging.ts
@@ -1,0 +1,42 @@
+import { sendPushMessage } from '~/lib/lineClient';
+import type { LineApiResponse } from '~/types/line';
+
+export const sendLineMessage = async (
+  message: string
+): Promise<LineApiResponse> => {
+  const channelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  const userID = process.env.LINE_USER_ID;
+
+  if (!channelAccessToken || !userID) {
+    return {
+      status: 400,
+      message:
+        'LINE_CHANNEL_ACCESS_TOKEN and LINE_USER_ID environment variables are required',
+    };
+  }
+
+  return await sendPushMessage(channelAccessToken, userID, message);
+};
+
+export const sendLineNotification = async (
+  message: string,
+  disableNotification = false
+): Promise<LineApiResponse> => {
+  const channelAccessToken = process.env.LINE_CHANNEL_ACCESS_TOKEN;
+  const userID = process.env.LINE_USER_ID;
+
+  if (!channelAccessToken || !userID) {
+    return {
+      status: 400,
+      message:
+        'LINE_CHANNEL_ACCESS_TOKEN and LINE_USER_ID environment variables are required',
+    };
+  }
+
+  return await sendPushMessage(
+    channelAccessToken,
+    userID,
+    message,
+    disableNotification
+  );
+};


### PR DESCRIPTION
## 概要

LINE Messaging APIとの接続設定を実装しました。

## 関連 Issue

Closes #15

## 対応詳細

- LINE Messaging APIクライアント関数の実装 (`app/lib/lineClient.ts`)
- LINE API用のタイプ定義の追加 (`app/types/line.ts`, `app/types/env.ts`)
- メッセージ送信ユーティリティ関数の追加 (`app/utils/lineMessaging.ts`)
- 環境変数設定例ファイルの追加 (`.env.example`)
- 環境変数による設定管理とエラーハンドリングの実装
- タイムアウト設定 (5秒) とAbortSignalによるリクエスト制御
- 適切なエラーレスポンス形式の統一

🤖 Generated with [Claude Code](https://claude.ai/code)