### PR TITLE
🤖 issue-5: 個数の周りにプラスマイナスボタンを追加

### DIFF
--- a/app/components/stock/StockTable/StockTable.css.ts
+++ b/app/components/stock/StockTable/StockTable.css.ts
@@ -29,3 +29,9 @@ export const link = style({
   color: '#0066cc',
   textDecoration: 'underline',
 });
+
+export const buttonContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+});

--- a/app/components/stock/StockTable/StockTable.tsx
+++ b/app/components/stock/StockTable/StockTable.tsx
@@ -1,12 +1,38 @@
 import type { FC } from 'react';
+import { useState } from 'react';
+import axios from 'axios';
 import * as styles from './StockTable.css';
 import type { StockItem } from '~/types/stock';
+import { Button } from '~/components';
+import { API_URL } from '~/config';
 
 interface StockTableProps {
   data: StockItem[];
 }
 
 export const StockTable: FC<StockTableProps> = ({ data }) => {
+  const [stockData, setStockData] = useState<StockItem[]>(data);
+
+  const handleCountChange = async (id: number, action: 'add' | 'sub') => {
+    try {
+      const endpoint = action === 'add' ? '/stock/add' : '/stock/sub';
+      await axios.post(`${API_URL}${endpoint}`, { id });
+
+      setStockData((prevData) =>
+        prevData.map((item) =>
+          item.id === id
+            ? {
+                ...item,
+                count: action === 'add' ? item.count + 1 : item.count - 1,
+              }
+            : item
+        )
+      );
+    } catch (error) {
+      console.error('在庫更新エラー:', error);
+    }
+  };
+
   return (
     <div className={styles.tableContainer}>
       <table className={styles.table}>
@@ -19,11 +45,29 @@ export const StockTable: FC<StockTableProps> = ({ data }) => {
           </tr>
         </thead>
         <tbody>
-          {data.map((item) => (
+          {stockData.map((item) => (
             <tr key={item.id}>
               <td className={styles.td}>{item.id}</td>
               <td className={styles.td}>{item.name}</td>
-              <td className={styles.td}>{item.count}</td>
+              <td className={styles.td}>
+                <div
+                  style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
+                >
+                  <Button
+                    disabled={item.count <= 0}
+                    onClick={() => handleCountChange(item.id, 'sub')}
+                  >
+                    -
+                  </Button>
+                  <span>{item.count}</span>
+                  <Button
+                    disabled={item.count >= 20}
+                    onClick={() => handleCountChange(item.id, 'add')}
+                  >
+                    +
+                  </Button>
+                </div>
+              </td>
               <td className={styles.td}>
                 <a
                   href={decodeURIComponent(item.url)}

--- a/app/components/stock/StockTable/StockTable.tsx
+++ b/app/components/stock/StockTable/StockTable.tsx
@@ -1,37 +1,15 @@
 import type { FC } from 'react';
-import { useState } from 'react';
-import axios from 'axios';
 import * as styles from './StockTable.css';
 import type { StockItem } from '~/types/stock';
 import { Button } from '~/components';
-import { API_URL } from '~/config';
+import { useStock } from '~/hooks';
 
 interface StockTableProps {
   data: StockItem[];
 }
 
 export const StockTable: FC<StockTableProps> = ({ data }) => {
-  const [stockData, setStockData] = useState<StockItem[]>(data);
-
-  const handleCountChange = async (id: number, action: 'add' | 'sub') => {
-    try {
-      const endpoint = action === 'add' ? '/stock/add' : '/stock/sub';
-      await axios.post(`${API_URL}${endpoint}`, { id });
-
-      setStockData((prevData) =>
-        prevData.map((item) =>
-          item.id === id
-            ? {
-                ...item,
-                count: action === 'add' ? item.count + 1 : item.count - 1,
-              }
-            : item
-        )
-      );
-    } catch (error) {
-      console.error('在庫更新エラー:', error);
-    }
-  };
+  const { stockData, addStock, subStock } = useStock(data);
 
   return (
     <div className={styles.tableContainer}>
@@ -50,19 +28,17 @@ export const StockTable: FC<StockTableProps> = ({ data }) => {
               <td className={styles.td}>{item.id}</td>
               <td className={styles.td}>{item.name}</td>
               <td className={styles.td}>
-                <div
-                  style={{ display: 'flex', alignItems: 'center', gap: '8px' }}
-                >
+                <div className={styles.buttonContainer}>
                   <Button
                     disabled={item.count <= 0}
-                    onClick={() => handleCountChange(item.id, 'sub')}
+                    onClick={() => subStock(item.id)}
                   >
                     -
                   </Button>
                   <span>{item.count}</span>
                   <Button
                     disabled={item.count >= 20}
-                    onClick={() => handleCountChange(item.id, 'add')}
+                    onClick={() => addStock(item.id)}
                   >
                     +
                   </Button>

--- a/app/components/stock/StockTable/StockTable.tsx
+++ b/app/components/stock/StockTable/StockTable.tsx
@@ -3,6 +3,7 @@ import * as styles from './StockTable.css';
 import type { StockItem } from '~/types/stock';
 import { Button } from '~/components';
 import { useStock } from '~/hooks';
+import { stockConstants } from '~/utils/const';
 
 interface StockTableProps {
   data: StockItem[];
@@ -30,14 +31,14 @@ export const StockTable: FC<StockTableProps> = ({ data }) => {
               <td className={styles.td}>
                 <div className={styles.buttonContainer}>
                   <Button
-                    disabled={item.count <= 0}
+                    disabled={item.count <= stockConstants.MIN_STOCK_COUNT}
                     onClick={() => subStock(item.id)}
                   >
                     -
                   </Button>
                   <span>{item.count}</span>
                   <Button
-                    disabled={item.count >= 20}
+                    disabled={item.count >= stockConstants.MAX_STOCK_COUNT}
                     onClick={() => addStock(item.id)}
                   >
                     +

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from './useSpent';
+export * from './useStock';

--- a/app/hooks/useStock.ts
+++ b/app/hooks/useStock.ts
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+import axios from 'axios';
+import type { StockItem } from '~/types/stock';
+import { API_URL } from '~/config';
+
+interface UseStockReturn {
+  stockData: StockItem[];
+  addStock: (id: number) => Promise<void>;
+  subStock: (id: number) => Promise<void>;
+}
+
+export const useStock = (initialData: StockItem[]): UseStockReturn => {
+  const [stockData, setStockData] = useState<StockItem[]>(initialData);
+
+  const addStock = async (id: number) => {
+    try {
+      await axios.post(`${API_URL}/stock/add`, { id });
+
+      setStockData((prevData) =>
+        prevData.map((item) =>
+          item.id === id ? { ...item, count: item.count + 1 } : item
+        )
+      );
+    } catch (error) {
+      console.error('在庫追加エラー:', error);
+    }
+  };
+
+  const subStock = async (id: number) => {
+    try {
+      await axios.post(`${API_URL}/stock/sub`, { id });
+
+      setStockData((prevData) =>
+        prevData.map((item) =>
+          item.id === id ? { ...item, count: item.count - 1 } : item
+        )
+      );
+    } catch (error) {
+      console.error('在庫削除エラー:', error);
+    }
+  };
+
+  return {
+    stockData,
+    addStock,
+    subStock,
+  };
+};

--- a/app/hooks/useStock.ts
+++ b/app/hooks/useStock.ts
@@ -23,6 +23,7 @@ export const useStock = (initialData: StockItem[]): UseStockReturn => {
       );
     } catch (error) {
       console.error('在庫追加エラー:', error);
+      alert('在庫の追加に失敗しました。');
     }
   };
 
@@ -37,6 +38,7 @@ export const useStock = (initialData: StockItem[]): UseStockReturn => {
       );
     } catch (error) {
       console.error('在庫削除エラー:', error);
+      alert('在庫の削除に失敗しました。');
     }
   };
 

--- a/app/utils/const.ts
+++ b/app/utils/const.ts
@@ -6,6 +6,12 @@ export const errorMessages = {
   amountPositive: '金額は0以上の数値を入力してください',
 } as const;
 
+// 在庫管理関連の定数
+export const stockConstants = {
+  MIN_STOCK_COUNT: 0,
+  MAX_STOCK_COUNT: 20,
+} as const;
+
 // リンク一覧
 export const path = [
   {

--- a/app/utils/top.test.ts
+++ b/app/utils/top.test.ts
@@ -5,7 +5,7 @@ import type { DashboardSpentData } from '~/types/api';
 // config のモック
 vi.mock('~/config', () => ({
   RENT_AMOUNT: 50000,
-  SAVINGS_AMOUNT: 30000
+  SAVINGS_AMOUNT: 30000,
 }));
 
 describe('top utils', () => {
@@ -21,9 +21,9 @@ describe('top utils', () => {
         gas: 5000,
         water: 3000,
         other: 2000,
-        spending: 28000
+        spending: 28000,
       };
-      
+
       expect(shouldShowData(mockData)).toBe(true);
     });
 
@@ -34,9 +34,9 @@ describe('top utils', () => {
         gas: 5000,
         water: 3000,
         other: 2000,
-        spending: 20000
+        spending: 20000,
       };
-      
+
       // 現在の日付によって結果が変わるため、boolean値であることを確認
       const result = shouldShowData(mockData);
       expect(typeof result).toBe('boolean');
@@ -49,9 +49,9 @@ describe('top utils', () => {
         gas: 8000,
         water: 4000,
         other: 3000,
-        spending: 42000
+        spending: 42000,
       };
-      
+
       expect(shouldShowData(mockData)).toBe(true);
     });
   });
@@ -60,35 +60,35 @@ describe('top utils', () => {
     it('最初の人（isFirstPerson = true）の場合、追加20000円を加算する', () => {
       const baseAmount = 100000;
       const expected = baseAmount / 2 + 50000 + 20000 + 30000; // 150000
-      
+
       expect(calculatePersonAmount(baseAmount, true)).toBe(expected);
     });
 
     it('二番目の人（isFirstPerson = false）の場合、追加額なし', () => {
       const baseAmount = 100000;
       const expected = baseAmount / 2 + 50000 + 30000; // 130000
-      
+
       expect(calculatePersonAmount(baseAmount, false)).toBe(expected);
     });
 
     it('isFirstPersonを指定しない場合、falseとして扱われる', () => {
       const baseAmount = 100000;
       const expected = baseAmount / 2 + 50000 + 30000; // 130000
-      
+
       expect(calculatePersonAmount(baseAmount)).toBe(expected);
     });
 
     it('baseAmountが0の場合でも正しく計算される', () => {
       const baseAmount = 0;
       const expected = 0 / 2 + 50000 + 20000 + 30000; // 100000
-      
+
       expect(calculatePersonAmount(baseAmount, true)).toBe(expected);
     });
 
     it('負の数でも正しく計算される', () => {
       const baseAmount = -20000;
       const expected = -20000 / 2 + 50000 + 20000 + 30000; // 90000
-      
+
       expect(calculatePersonAmount(baseAmount, true)).toBe(expected);
     });
   });


### PR DESCRIPTION
## 概要

在庫一覧テーブルの各個数の周りにプラスマイナスボタンを追加しました。

## 関連 Issue

Closes #5

## 対応詳細

- 在庫個数の周りにプラス/マイナスボタンを実装
- 在庫が0以下または20以上の時はボタンをdisabledに設定
- Button.tsxコンポーネントを利用してボタンを実装
- プラス/マイナスボタン押下時に在庫個数追加/削除APIを呼び出し（`/stock/add`、`/stock/sub`）
- ローカルstateで在庫データを管理し、API呼び出し後に即座に画面を更新

🤖 Generated with [Claude Code](https://claude.ai/code)