### PR TITLE
🤖 issue-7: ログイン機能の作成

### DIFF
--- a/app/components/pages/login.tsx
+++ b/app/components/pages/login.tsx
@@ -1,15 +1,51 @@
-import type { FC } from 'react';
-import { H1, Input } from '~/components/common';
+import type { FC, FormEvent } from 'react';
+import { H1, Input, Button } from '~/components/common';
+import { useLogin } from '~/hooks';
 
 /**
  * ログインページ.
  */
 export const LoginPage: FC = () => {
+  const {
+    email,
+    password,
+    isLoading,
+    emailError,
+    passwordError,
+    setEmail,
+    setPassword,
+    handleLogin,
+  } = useLogin();
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    handleLogin();
+  };
+
   return (
     <>
-      <H1>ログインページ</H1>
-      <Input label="メールアドレス" />
-      <Input label="パスワード" />
+      <H1>ログイン</H1>
+      <form onSubmit={handleSubmit}>
+        <Input
+          label="メールアドレス"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={emailError}
+          disabled={isLoading}
+        />
+        <Input
+          label="パスワード"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={passwordError}
+          disabled={isLoading}
+        />
+        <Button type="submit" disabled={isLoading}>
+          {isLoading ? 'ログイン中...' : 'ログイン'}
+        </Button>
+      </form>
     </>
   );
 };

--- a/app/hooks/index.ts
+++ b/app/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useSpent';
 export * from './useStock';
+export * from './useLogin';

--- a/app/hooks/useLogin.ts
+++ b/app/hooks/useLogin.ts
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import axios from 'axios';
+import { API_URL } from '~/config';
+
+interface LoginData {
+  email: string;
+  password: string;
+}
+
+interface UseLoginReturn {
+  email: string;
+  password: string;
+  isLoading: boolean;
+  emailError: string;
+  passwordError: string;
+  setEmail: (email: string) => void;
+  setPassword: (password: string) => void;
+  handleLogin: () => Promise<void>;
+}
+
+export const useLogin = (): UseLoginReturn => {
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [emailError, setEmailError] = useState<string>('');
+  const [passwordError, setPasswordError] = useState<string>('');
+  const navigate = useNavigate();
+
+  const validateForm = (): boolean => {
+    let isValid = true;
+    setEmailError('');
+    setPasswordError('');
+
+    if (!email) {
+      setEmailError('メールアドレスを入力してください');
+      isValid = false;
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError('有効なメールアドレスを入力してください');
+      isValid = false;
+    }
+
+    if (!password) {
+      setPasswordError('パスワードを入力してください');
+      isValid = false;
+    }
+
+    return isValid;
+  };
+
+  const handleLogin = async (): Promise<void> => {
+    if (!validateForm()) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const loginData: LoginData = { email, password };
+      const response = await axios.post(`${API_URL}/login`, loginData);
+
+      if (response.status === 200) {
+        navigate('/stock');
+      }
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const message =
+          error.response.data?.message || 'ログインに失敗しました';
+        alert(message);
+      } else {
+        alert('ログインに失敗しました');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    email,
+    password,
+    isLoading,
+    emailError,
+    passwordError,
+    setEmail,
+    setPassword,
+    handleLogin,
+  };
+};


### PR DESCRIPTION
## 概要

ログインページ(/login)にログイン機能を実装しました。

## 関連 Issue

Closes #7

## 対応詳細

- ログインページにメールアドレス・パスワード入力フォームを追加
- useLoginフックを新規作成し、ログイン機能を実装
- バリデーション機能追加（必須チェック、メール形式チェック）
- ログインAPI（${API_URL}/login）との連携実装
- レスポンスが200の場合は在庫管理画面(/stock)に遷移
- レスポンスが200以外の場合はアラートでエラーメッセージを表示
- ローディング状態表示とボタンの無効化機能を追加

🤖 Generated with [Claude Code](https://claude.ai/code)