### PR TITLE
🤖 issue-41: API送信時にheaderにx-api-keyを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 VITE_API_URL="http://localhost:3000/api/v1"
+API_ACCESS_KEY=""
 
 # 家計簿計算用設定
 VITE_RENT_AMOUNT=50000

--- a/app/hooks/useAuth.ts
+++ b/app/hooks/useAuth.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
-import axios from 'axios';
-import { API_URL } from '~/config';
+import apiClient from '~/utils/api';
 import { enableAuth } from '~/utils/const';
 
 interface AuthResponse {
@@ -24,7 +23,7 @@ export const useAuth = (): UseAuthReturn => {
   const checkAuth = async (): Promise<void> => {
     try {
       if (!enableAuth) return;
-      const response = await axios.get<AuthResponse>(`${API_URL}/auth/status`);
+      const response = await apiClient.get<AuthResponse>('/auth/status');
 
       setIsAuthenticated(response.data.authenticated);
     } catch (error) {

--- a/app/hooks/useLogin.ts
+++ b/app/hooks/useLogin.ts
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import axios from 'axios';
-import { API_URL } from '~/config';
+import apiClient from '~/utils/api';
 import { loginSchema, type LoginFormData } from '~/schemas/loginValidation';
 
 export const useLogin = () => {
@@ -23,7 +23,9 @@ export const useLogin = () => {
 
     try {
       axios.defaults.withCredentials = true;
-      const response = await axios.post(`${API_URL}/auth/login`, data);
+      const response = await apiClient.post('/auth/login', data, {
+        withCredentials: true,
+      });
 
       if (response.status === 200) {
         navigate('/');
@@ -48,7 +50,7 @@ export const useLogin = () => {
     setIsLoading(true);
 
     try {
-      const response = await axios.post(`${API_URL}/auth/logout`);
+      const response = await apiClient.post('/auth/logout');
 
       if (response.status === 200) {
         navigate('/login');

--- a/app/hooks/useSpent.ts
+++ b/app/hooks/useSpent.ts
@@ -6,7 +6,7 @@ import type {
   ErrorResponse,
   MonthlySpentData,
 } from '~/types/api';
-import { API_URL } from '~/config';
+import apiClient from '~/utils/api';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 
@@ -55,7 +55,7 @@ export const useSpent = (initialData?: MonthlySpentData) => {
         other: Number(data.other),
       };
 
-      await axios.post(`${API_URL}/spent/month`, requestData);
+      await apiClient.post('/spent/month', requestData);
 
       alert('登録しました');
       navigate('/');

--- a/app/hooks/useStock.ts
+++ b/app/hooks/useStock.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react';
-import axios from 'axios';
 import type { StockItem } from '~/types/stock';
-import { API_URL } from '~/config';
+import apiClient from '~/utils/api';
 
 interface UseStockReturn {
   stockData: StockItem[];
@@ -14,7 +13,7 @@ export const useStock = (initialData: StockItem[]): UseStockReturn => {
 
   const addStock = async (id: number) => {
     try {
-      await axios.post(`${API_URL}/stock/add`, { id });
+      await apiClient.post('/stock/add', { id });
 
       setStockData((prevData) =>
         prevData.map((item) =>
@@ -29,7 +28,7 @@ export const useStock = (initialData: StockItem[]): UseStockReturn => {
 
   const subStock = async (id: number) => {
     try {
-      await axios.post(`${API_URL}/stock/sub`, { id });
+      await apiClient.post('/stock/sub', { id });
 
       setStockData((prevData) =>
         prevData.map((item) =>

--- a/app/utils/api.ts
+++ b/app/utils/api.ts
@@ -1,0 +1,16 @@
+import axios from 'axios';
+import { API_URL } from '~/config';
+
+const apiClient = axios.create({
+  baseURL: API_URL,
+});
+
+apiClient.interceptors.request.use((config) => {
+  const apiAccessKey = import.meta.env.API_ACCESS_KEY;
+  if (apiAccessKey) {
+    config.headers['x-api-key'] = apiAccessKey;
+  }
+  return config;
+});
+
+export default apiClient;


### PR DESCRIPTION
## 概要

API送信時にheaderにx-api-keyの値を付与する機能を実装しました。

## 関連 Issue

Closes #41

## 対応詳細

- 共通のapiClientを作成してx-api-keyヘッダーを自動付与する仕組みを構築
- 環境変数API_ACCESS_KEYからx-api-keyの値を取得するように設定
- 全てのAPI通信で個別のaxios呼び出しからapiClientに統一
- useSpent, useStock, useAuth, useLoginのAPI呼び出しを共通化
- .env.exampleにAPI_ACCESS_KEYの設定例を追加